### PR TITLE
Change colour sequence of blocks on homepage

### DIFF
--- a/wp-content/themes/qavs/inc/blocks.php
+++ b/wp-content/themes/qavs/inc/blocks.php
@@ -107,13 +107,14 @@ function qavs_block__promoted_article( $block_attributes, $content ) {
 
   foreach($featured_news as $news) {
     $html .= '<article id="post-' . $news["ID"]. '" class="promoted-article">';
-    $html .= qavs_post_thumbnail($news["ID"]);
     $html .= '<div class="promoted-article__details">';
     $html .= '<h3 class="promoted-article__title" id="title-' . $news["ID"] . '">' . get_the_title($news["ID"]) . '</h3>';
     $html .= '<div class="promoted-article__meta">';
     $html .= qavs_posted_on($news["ID"]);
     $html .= '</div>';
-    $html .= '<a href="' . esc_url( get_permalink($news["ID"]) ) . '" rel="bookmark" aria-label="Read article: ' .  get_the_title($news["ID"]) . '" title="Click to read article" class="promoted-article__cta arrow-link">Read article</a></div></article>';
+    $html .= '<a href="' . esc_url( get_permalink($news["ID"]) ) . '" rel="bookmark" aria-label="Read article: ' .  get_the_title($news["ID"]) . '" title="Click to read article" class="promoted-article__cta arrow-link">Read article</a></div>';
+    $html .= qavs_post_thumbnail($news["ID"]);
+    $html .= '</article>';
   }
 
   return $html;

--- a/wp-content/themes/qavs/style.css
+++ b/wp-content/themes/qavs/style.css
@@ -2443,9 +2443,19 @@ p.has-medium-font-size {
 
 .promoted-article {
   display: flex;
+  margin-bottom: 2rem;
+  margin-top: 4rem;
+  background: #f7f7f7;
+  border-left: 10px solid #8A0DA6;
+  padding: 2rem 0;
+  align-items: center;
+}
+
+.promoted-article-purple {
+  display: flex;
   margin: 2rem 0;
   background: #f7f7f7;
-  border-right: 10px solid #47A14E;
+  border-left: 10px solid #8A0DA6;
   padding: 2rem 0;
   align-items: center;
 }


### PR DESCRIPTION
## 📝 A short description of the changes

* 

## 🔗 Link to the relevant story (or stories)

* https://app.asana.com/0/1199154381249427/1205961315051901/f

## :shipit: Deployment implications

* 
<img width="890" alt="Screenshot 2023-11-16 at 2 53 50 pm" src="https://github.com/bitzesty/qavs-v2-wordpress/assets/84323332/90568faa-dcfe-4f4a-a3cc-7df8e3bfd624">


## ✅ Checklist

- [x] Features that cannot go live are behind a feature flag/env var or specify deploy date and open PR as draft 
- [x] I have checked that commit messages make sense and explain the reasoning for each change
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have squashed any unnecessary or part-finished commits

## 🖼️ Screenshots (if appropriate - no PII/Prod data):

